### PR TITLE
use less specific version locking to avoid conflicts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source "http://rubygems.org"
 
 gem 'rack', '~> 1.4.5'
-gem 'actionpack', '~> 3.2.13'
-gem 'activesupport', '~> 3.2.13'
+gem 'actionpack', '~> 3.2'
+gem 'activesupport', '~> 3.2'
 
 group :development do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,8 +58,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionpack (~> 3.2.13)
-  activesupport (~> 3.2.13)
+  actionpack (~> 3.2)
+  activesupport (~> 3.2)
   bundler
   jeweler
   rack (~> 1.4.5)

--- a/heroku_rails_deflate.gemspec
+++ b/heroku_rails_deflate.gemspec
@@ -44,24 +44,24 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rack>, ["~> 1.4.5"])
-      s.add_runtime_dependency(%q<actionpack>, ["~> 3.2.13"])
-      s.add_runtime_dependency(%q<activesupport>, ["~> 3.2.13"])
+      s.add_runtime_dependency(%q<rack>, ["~> 1.4"])
+      s.add_runtime_dependency(%q<actionpack>, ["~> 3.2"])
+      s.add_runtime_dependency(%q<activesupport>, ["~> 3.2"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<bundler>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
     else
-      s.add_dependency(%q<rack>, ["~> 1.4.5"])
-      s.add_dependency(%q<actionpack>, ["~> 3.2.13"])
-      s.add_dependency(%q<activesupport>, ["~> 3.2.13"])
+      s.add_dependency(%q<rack>, ["~> 1.4"])
+      s.add_dependency(%q<actionpack>, ["~> 3.2"])
+      s.add_dependency(%q<activesupport>, ["~> 3.2"])
       s.add_dependency(%q<rspec>, [">= 0"])
       s.add_dependency(%q<bundler>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 0"])
     end
   else
-    s.add_dependency(%q<rack>, ["~> 1.4.5"])
-    s.add_dependency(%q<actionpack>, ["~> 3.2.13"])
-    s.add_dependency(%q<activesupport>, ["~> 3.2.13"])
+    s.add_dependency(%q<rack>, ["~> 1.4"])
+    s.add_dependency(%q<actionpack>, ["~> 3.2"])
+    s.add_dependency(%q<activesupport>, ["~> 3.2"])
     s.add_dependency(%q<rspec>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])


### PR DESCRIPTION
your gem requirements were causing conflicts for me in a production app so I needed to loosen them. Hopefully you agree with these changes.
