### PR TITLE
Ensure we close the body to avoid deadlock error

### DIFF
--- a/lib/heroku_rails_deflate/serve_zipped_assets.rb
+++ b/lib/heroku_rails_deflate/serve_zipped_assets.rb
@@ -49,7 +49,9 @@ module HerokuRailsDeflate
         end
       end
 
-      @app.call(env)
+      status, headers, body = @app.call(env)
+      body.close if body.respond_to?(:close)
+      [status, headers, body]
     end
   end
 end


### PR DESCRIPTION
This commit is should fix the "ThreadError; deadlock; recursive locking" error was reported in #4, though I am not certain of it yet as I only get this error intermittently.

I'm running this patch in production right now and have a search on my logs set up to notify me if the error occurs again. I'll report my results back in a few days.

At a minimum, this change does not seem to interfere with the gem's normal functionality, and should be safe to merge.
